### PR TITLE
Removed trailing comma on PCM metadata template

### DIFF
--- a/PCM/metadata.template.json
+++ b/PCM/metadata.template.json
@@ -8,13 +8,13 @@
     "author": {
         "name": "hlord2000",
         "contact": {
-            "github": "hlord2000",
+            "github": "hlord2000"
         }
     },
     "maintainer": {
         "name": "hlord2000",
         "contact": {
-            "github": "hlord2000",
+            "github": "hlord2000"
         }
     },
     "license": "MIT",


### PR DESCRIPTION
This following error showed up due to the trailing comma on metadata.json, causing "Install from File" and adding the repo to fail.

<img width="961" height="563" alt="image" src="https://github.com/user-attachments/assets/713995ad-0f4b-4030-8813-b11b547c6574" />

Changes I made to `PCM/metadata.template.json`:
<img width="456" height="233" alt="image" src="https://github.com/user-attachments/assets/357e1956-e95f-4b1e-ad07-e014d0d7d363" />